### PR TITLE
Updated countries gem from 4.1.2 to 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "cssbundling-rails"
 
 # ActiveRecord
 gem "pg", "~> 1.1"
-gem "countries"
+gem "countries", "~> 4.2"
 gem "credit_card_validations"
 
 # Infrastructure

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,8 +78,8 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     concurrent-ruby (1.1.9)
-    countries (4.1.2)
-      i18n_data (~> 0.15.0)
+    countries (4.2.3)
+      i18n_data (~> 0.16.0)
       sixarm_ruby_unaccent (~> 1.1)
     crass (1.0.6)
     credit_card_validations (3.3.0)
@@ -104,7 +104,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.15.0)
+    i18n_data (0.16.0)
       simple_po_parser (~> 1.1)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
@@ -214,7 +214,7 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    simple_po_parser (1.1.5)
+    simple_po_parser (1.1.6)
     sixarm_ruby_unaccent (1.2.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -256,7 +256,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
-  countries
+  countries (~> 4.2)
   credit_card_validations
   cssbundling-rails
   debug


### PR DESCRIPTION
Fixes https://github.com/abhishekgupta5/ecommerce-rails-app-test/issues/1

Brief: The Gemfile.lock explicitly locked the gem at 4.1.2. The code uses
iso_short_name which is available in and after 4.2 ([Official remark)](https://github.com/countries/countries#upgrading-to-42-and-5x)

Way to reproduce: Building locally without fix will not let you checkout. More description in the https://github.com/nebulab/abhishek-gupta-techincal-test/issues/1

Solution: Locked the gem to use ~>4.2(stable version)

Why this is an atomic PR: This is a gem version upgrade and it's good to keep it separate from the rest of the project. This also makes it independently revertable in case if needed without reverting anything else.