### PR TITLE
Assignment 1A - Added functionality to manage shipping methods

### DIFF
--- a/app/models/shipping_method.rb
+++ b/app/models/shipping_method.rb
@@ -2,4 +2,42 @@ class ShippingMethod < ApplicationRecord
   validates :name, presence: true
   validates :delivery_time_in_days, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 1}
   validates :country, presence: true, uniqueness: true, inclusion: {in: ISO3166::Country.pluck(:alpha2).flatten}
+
+  class << self
+    # Generic method to add a shipping_method. Expects valid name, delivery_time_in_days
+    # and country
+    # Raises error if unable to add a record
+    def add(attributes)
+      ShippingMethod.create!(
+        name: attributes[:name],
+        country: attributes[:country],
+        delivery_time_in_days: attributes[:delivery_time_in_days]
+      )
+    end
+
+    # @param name [String] Shipping method name
+    # @param countries_to_delivery_time_map [Hash] map of countries to delivery_time
+    # Eg - { "IN": 2, "US": 3 }
+    # Raises error if unable to add a record. If a record is invalid,
+    # later records are ignored
+    # Used to add a specific shipping method to multiple countries
+    # with different delivery times
+    def add_for_countries(name, countries_to_delivery_time_map)
+      countries_to_delivery_time_map.each do |country, delivery_time|
+        ShippingMethod.create!(
+          name: name,
+          country: country,
+          delivery_time_in_days: delivery_time
+        )
+      end
+    end
+
+    # @param country [String] alpha2 country code
+    # @return [ShippingMethod] deleted object
+    # Raises error if not found
+    # Delete a shipping_method for a country
+    def delete_for_country(country)
+      ShippingMethod.find_by_country!(country).destroy!
+    end
+  end
 end

--- a/app/models/shipping_method.rb
+++ b/app/models/shipping_method.rb
@@ -1,0 +1,5 @@
+class ShippingMethod < ApplicationRecord
+  validates :name, presence: true
+  validates :delivery_time_in_days, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 1}
+  validates :country, presence: true, uniqueness: true, inclusion: {in: ISO3166::Country.pluck(:alpha2).flatten}
+end

--- a/spec/factories/shipping_methods.rb
+++ b/spec/factories/shipping_methods.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :shipping_method do
+    name { Faker::Name.name }
+    delivery_time_in_days { Faker::Number.within(range: 1..10) }
+    country { Faker::Address.country_code }
+  end
+end

--- a/spec/models/shipping_method_spec.rb
+++ b/spec/models/shipping_method_spec.rb
@@ -29,4 +29,48 @@ RSpec.describe ShippingMethod, type: :model do
     create(:shipping_method, country: :IN)
     expect(build_stubbed(:shipping_method, country: :IN)).to_not be_valid
   end
+
+  describe "#add" do
+    it "creates shipping method with valid attributes" do
+      expect do
+        ShippingMethod.add(shipping_method_valid_attributes)
+      end.to change { ShippingMethod.count }.by(1)
+    end
+  end
+
+  describe "#add_for_countries" do
+    it "creates shipping method with valid attributes" do
+      expect do
+        ShippingMethod.add_for_countries("fedex", countries_to_delivery_time_map)
+      end.to change { ShippingMethod.count }.by(3)
+      # Check data
+      expect(ShippingMethod.where(country: countries_to_delivery_time_map.keys)
+                           .pluck(:name, :country, :delivery_time_in_days))
+        .to match_array(expected_response_add_for_countries)
+    end
+  end
+
+  describe "#delete_for_country" do
+    it "deletes shipping method for a country" do
+      record = create(:shipping_method, country: "IN")
+      expect do
+        ShippingMethod.delete_for_country("IN")
+      end.to change { ShippingMethod.count }.by(-1)
+      expect { record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  private
+
+  def shipping_method_valid_attributes
+    {name: "fedex", country: "IN", delivery_time_in_days: 10}
+  end
+
+  def countries_to_delivery_time_map
+    {IN: 5, US: 2, IT: 3}
+  end
+
+  def expected_response_add_for_countries
+    [["fedex", "IN", 5], ["fedex", "US", 2], ["fedex", "IT", 3]]
+  end
 end

--- a/spec/models/shipping_method_spec.rb
+++ b/spec/models/shipping_method_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ShippingMethod, type: :model do
+  it "has a valid factory" do
+    expect(build_stubbed(:shipping_method)).to be_valid
+  end
+
+  it "validates the presence of name" do
+    expect(build_stubbed(:shipping_method, name: nil)).not_to be_valid
+  end
+
+  it "validates the presence of delivery_time_in_days" do
+    expect(build_stubbed(:shipping_method, delivery_time_in_days: nil)).not_to be_valid
+  end
+
+  it "validates the presence of country" do
+    expect(build_stubbed(:shipping_method, country: nil)).not_to be_valid
+  end
+
+  it "validates that any invalid country isn't saved" do
+    expect(build_stubbed(:shipping_method, country: "RANDOM")).not_to be_valid
+  end
+
+  it "validates the numericality of delivery_time_in_days" do
+    expect(build_stubbed(:shipping_method, delivery_time_in_days: 0)).not_to be_valid
+  end
+
+  it "validates uniqueness of country" do
+    create(:shipping_method, country: :IN)
+    expect(build_stubbed(:shipping_method, country: :IN)).to_not be_valid
+  end
+end


### PR DESCRIPTION
**Related Asignment:** [1](https://github.com/abhishekgupta5/ecommerce-rails-app-test#assignment-1-delivery-estimates)
**Brief:** Added model functionality to manage shipping methods via rails console. There are 3 methods -
1. To add a shipping method for a country
2. To add a shipping method to multuiple countries with respective delivery time
3. To delete a shipping method.

**Usage from rails console -** (check method documentation or commit message for detailed doc)
```
ShippingMethod.add({ name: "fedex", country: "IN", delivery_time_in_days: 3 })
ShippingMethod.add_for_countries("fedex", { "IN": 2, "US": 3 })
ShippingMethod.delete_for_country("US")
```

Added unit tests in `shipping_method_spec.rb` for each of them. Factory is added to support specs.

**Why is this PR atomic:** These is one single task which can be deployed independently. It doesn't affect the user interface so the risk for breaking anything is less.

**Note:** This PR is rebased on the Migration [PR](https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/3) and depends on it to be merged first.

--------
Rationale behind some decisions -
1. ShippingMethods related methods are in the model itself. These can be abstracted out in a module but since this is the only place these will be read from at the moment, can keep it here for now. Also, the file is not too big right now.
2. `delivery_time_in_days` seems to be a big name but `delivery_time` could have been interpreted as a time attribute. Hence kept the bigger name to avoid the confusion.
3. Since there's no auth in the existing code, or a user entity, the store operator is assumed to be an admin who has access to rails console