### PR TITLE
Assignment 1B and 1C - Added functionality to avoid non-deliverable orders and show appropriate info to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "cssbundling-rails"
 
 # ActiveRecord
 gem "pg", "~> 1.1"
-gem "countries"
+gem "countries", "~> 4.2"
 gem "credit_card_validations"
 
 # Infrastructure

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,8 +78,8 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     concurrent-ruby (1.1.9)
-    countries (4.1.2)
-      i18n_data (~> 0.15.0)
+    countries (4.2.3)
+      i18n_data (~> 0.16.0)
       sixarm_ruby_unaccent (~> 1.1)
     crass (1.0.6)
     credit_card_validations (3.3.0)
@@ -104,7 +104,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.15.0)
+    i18n_data (0.16.0)
       simple_po_parser (~> 1.1)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
@@ -214,7 +214,7 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    simple_po_parser (1.1.5)
+    simple_po_parser (1.1.6)
     sixarm_ruby_unaccent (1.2.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -256,7 +256,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
-  countries
+  countries (~> 4.2)
   credit_card_validations
   cssbundling-rails
   debug

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -7,6 +7,9 @@ class OrdersController < ApplicationController
     @order = build_order(order_params)
 
     if @order.save
+      shipping_method = ShippingMethod.find_by_country(@order.shipping_address.country)
+      @delivery_info = {shipping_method_name: shipping_method&.name,
+                        delivery_time: shipping_method&.delivery_time_in_days}
       cart.clear
       render :summary
     else

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -14,6 +14,18 @@ class OrdersController < ApplicationController
     end
   end
 
+  def delivery_info
+    @delivery_info_target = params[:delivery_info_target]
+    @submit_button_target = params[:submit_button_target]
+    @turbo_frame_target = params[:turbo_frame_target]
+    shipping_method = ShippingMethod.find_by_country(params[:country])
+    @delivery_info = {shipping_method_name: shipping_method&.name,
+                      delivery_time: shipping_method&.delivery_time_in_days}
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
   private
 
   def build_order(params = {})

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -7,9 +7,7 @@ class OrdersController < ApplicationController
     @order = build_order(order_params)
 
     if @order.save
-      shipping_method = ShippingMethod.find_by_country(@order.shipping_address.country)
-      @delivery_info = {shipping_method_name: shipping_method&.name,
-                        delivery_time: shipping_method&.delivery_time_in_days}
+      @delivery_info = @order.shipping_info_for_order
       cart.clear
       render :summary
     else
@@ -21,9 +19,7 @@ class OrdersController < ApplicationController
     @delivery_info_target = params[:delivery_info_target]
     @submit_button_target = params[:submit_button_target]
     @turbo_frame_target = params[:turbo_frame_target]
-    shipping_method = ShippingMethod.find_by_country(params[:country])
-    @delivery_info = {shipping_method_name: shipping_method&.name,
-                      delivery_time: shipping_method&.delivery_time_in_days}
+    @delivery_info = ShippingMethod.delivery_info_for_country(params[:country])
     respond_to do |format|
       format.turbo_stream
     end

--- a/app/javascript/controllers/country_controller.js
+++ b/app/javascript/controllers/country_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+import { get } from "@rails/request.js"
+
+export default class extends Controller {
+  change(event) {
+    // TODO: Get the tag ids in a better way instead of hardcoding
+    let delivery_info_target = "delivery-info"
+    let submit_button_target = "submit-button"
+    let turbo_frame_target = "submit-button-turbo-frame"
+    let country = event.target.selectedOptions[0].value
+    get(`/orders/delivery_info?turbo_frame_target=${turbo_frame_target}&delivery_info_target=${delivery_info_target}&submit_button_target=${submit_button_target}&country=${country}`, {
+      responseKind: "turbo-stream"
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,3 +3,6 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from "./application"
+
+import CountryController from "./country_controller"
+application.register("country", CountryController)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,4 +12,10 @@ class Order < ApplicationRecord
   def total
     line_items.sum(&:total)
   end
+
+  # @return [Hash] containing shipping_method_name and
+  # delivery_time(in days)
+  def shipping_info_for_order
+    ShippingMethod.delivery_info_for_country(shipping_address.country)
+  end
 end

--- a/app/models/shipping_method.rb
+++ b/app/models/shipping_method.rb
@@ -39,5 +39,14 @@ class ShippingMethod < ApplicationRecord
     def delete_for_country(country)
       ShippingMethod.find_by_country!(country).destroy!
     end
+
+    # @param country [String] alpha2 id of the country
+    # @return [Hash] containing shipping_method_name and
+    # delivery_time(in days)
+    def delivery_info_for_country(country)
+      shipping_method = ShippingMethod.find_by_country(country)
+      {shipping_method_name: shipping_method&.name,
+       delivery_time: shipping_method&.delivery_time_in_days}
+    end
   end
 end

--- a/app/models/shipping_method.rb
+++ b/app/models/shipping_method.rb
@@ -2,4 +2,42 @@ class ShippingMethod < ApplicationRecord
   validates :name, presence: true
   validates :delivery_time_in_days, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 1}
   validates :country, presence: true, uniqueness: true, inclusion: {in: ISO3166::Country.pluck(:alpha2).flatten}
+
+  class << self
+    # Generic method to add a shipping_method. Expects valid name, delivery_time_in_days
+    # and country
+    # Raises error if unable to add a record
+    def add(attributes)
+      ShippingMethod.create!(
+        name: attributes[:name],
+        country: attributes[:country],
+        delivery_time_in_days: attributes[:delivery_time_in_days]
+      )
+    end
+
+    # @param name [String] Shipping method name
+    # @param countries_to_delivery_time_map [Hash] map of countries to delivery_time
+    # Eg - { "IN": 2, "US": 3 }
+    # Raises error if unable to add a record. If a record is invalid,
+    # later records are ignored
+    # Used to add a specific shipping method to multiple countries
+    # with different delivery times
+    def add_for_countries(name, countries_to_delivery_time_map)
+      countries_to_delivery_time_map.each do |country, delivery_time|
+        ShippingMethod.create!(
+          name: name,
+          country: country,
+          delivery_time_in_days: delivery_time
+        )
+      end
+    end
+
+    # @param country [String] alpha2 country code
+    # @return [ShippingMethod] deleted object
+    # Raises error if not found
+    # Delete a shipping_method for a country
+    def delete_for_country(country)
+      ShippingMethod.find_by_country!(country).destroy!
+    end
+  end
 end

--- a/app/models/shipping_method.rb
+++ b/app/models/shipping_method.rb
@@ -1,0 +1,5 @@
+class ShippingMethod < ApplicationRecord
+  validates :name, presence: true
+  validates :delivery_time_in_days, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 1}
+  validates :country, presence: true, uniqueness: true, inclusion: {in: ISO3166::Country.pluck(:alpha2).flatten}
+end

--- a/app/views/orders/_confirm_button.html.erb
+++ b/app/views/orders/_confirm_button.html.erb
@@ -1,0 +1,3 @@
+<div class="border-t border-gray-200 py-6 px-4 sm:px-6", id="submit-button">
+  <button type="submit" class="w-full bg-indigo-600 border border-transparent rounded-md shadow-sm py-3 px-4 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-50 focus:ring-indigo-500">Confirm order</button>
+</div>

--- a/app/views/orders/delivery_info.turbo_stream.erb
+++ b/app/views/orders/delivery_info.turbo_stream.erb
@@ -1,0 +1,14 @@
+<% if @delivery_info[:shipping_method_name].present? %>
+  <%# This is a country where we deliver %>
+  <%# We render partial Confirm button since it may have been removed if user had selected an non-deliverable country %>
+  <%= turbo_stream.update(@turbo_frame_target, partial: "confirm_button") %>
+  <%= turbo_stream.update @delivery_info_target do %>
+    Your order will reach by <b><%=@delivery_info[:shipping_method_name]%></b> within <b><%=@delivery_info[:delivery_time]%> days</b>
+  <%end %>
+  <% else %>
+  <%# This is a country where we don't deliver %>
+  <%= turbo_stream.remove @submit_button_target %>
+    <%= turbo_stream.update @delivery_info_target do %>
+      Sorry, we don't deliver in your country yet!
+  <% end %>
+<% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -91,10 +91,12 @@
             </div>
           </div>
 
-          <div>
-            <label for="country" class="block text-sm font-medium text-gray-700">Country</label>
-            <div class="mt-1">
-              <%= a.select :country, ISO3166::Country.pluck(:iso_short_name, :alpha2), {}, autocomplete: "country-name", id: "country", class: "block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm" %>
+          <div data-controller="country">
+            <div>
+              <label for="country" class="block text-sm font-medium text-gray-700">Country</label>
+              <div class="mt-1">
+                <%= a.select :country, ISO3166::Country.pluck(:iso_short_name, :alpha2), {}, { autocomplete: "country-name", id: "country", class: "block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm", data: { action: "change->country#change" } } %>
+              </div>
             </div>
           </div>
         <% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -188,9 +188,11 @@
         </div>
       </dl>
 
-      <div class="border-t border-gray-200 py-6 px-4 sm:px-6">
-        <button type="submit" class="w-full bg-indigo-600 border border-transparent rounded-md shadow-sm py-3 px-4 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-50 focus:ring-indigo-500">Confirm order</button>
-      </div>
+      <%= turbo_frame_tag "submit-button-turbo-frame" do%>
+        <%= render "confirm_button" %>
+      <% end %>
+
+      <div id="delivery-info"> <p></p></div>
     </div>
   </div>
 <% end %>

--- a/app/views/orders/summary.html.erb
+++ b/app/views/orders/summary.html.erb
@@ -1,3 +1,3 @@
 <h1 class="text-sm font-semibold uppercase tracking-wide text-indigo-600">Thank you!</h1>
 <p class="mt-2 font-extrabold tracking-tight text-5xl">It's on the way!</p>
-<p class="mt-2 text-base text-gray-500">Your order #<%= @order.id %> has shipped and will be with you soon.</p>
+<p class="mt-2 text-base text-gray-500">Your order #<%= @order.id %> has been shipped via <%= @delivery_info[:shipping_method_name] %> and will be with you within <%= @delivery_info[:delivery_time] %> days.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
   namespace :erp, defaults: {format: :json} do
     resources :orders, only: :create
   end
+
+  get "orders/delivery_info", to: "orders#delivery_info"
 end

--- a/db/migrate/20220328115022_create_shipping_methods.rb
+++ b/db/migrate/20220328115022_create_shipping_methods.rb
@@ -1,0 +1,12 @@
+class CreateShippingMethods < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shipping_methods do |t|
+      t.string :name, null: false
+      t.string :country, null: false
+      t.integer :delivery_time_in_days, null: false
+
+      t.index [:country], name: :index_shipping_methods_country_uniq, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_21_104017) do
+ActiveRecord::Schema.define(version: 2022_03_28_115022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,15 @@ ActiveRecord::Schema.define(version: 2021_12_21_104017) do
     t.decimal "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "shipping_methods", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "country", null: false
+    t.integer "delivery_time_in_days", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["country"], name: "index_shipping_methods_country_uniq", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": "true",
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
-    "@hotwired/turbo-rails": "^7.1.0",
+    "@hotwired/turbo-rails": "^7.1.1",
+    "@rails/request.js": "^0.0.6",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.4.0",
     "autoprefixer": "^10.4.0",

--- a/spec/factories/shipping_methods.rb
+++ b/spec/factories/shipping_methods.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :shipping_method do
+    name { Faker::Name.name }
+    delivery_time_in_days { Faker::Number.within(range: 1..10) }
+    country { Faker::Address.country_code }
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -23,4 +23,24 @@ RSpec.describe Order do
       expect(order.total).to eq(35.0)
     end
   end
+
+  describe "#shipping_info_for_order" do
+    it "returns value when shipping method is present" do
+      address = build_stubbed(:address)
+      shipping_method = build_stubbed(:shipping_method, country: address.country)
+      build_stubbed(:order, shipping_address: address) do |o|
+        allow(o).to receive(:shipping_info_for_order).and_return({shipping_method_name: shipping_method.name,
+                                                                  delivery_time: shipping_method.delivery_time_in_days})
+      end
+    end
+
+    it "returns nil values when shipping method is absent" do
+      address = build_stubbed(:address)
+      ShippingMethod.where(country: address.country).delete_all
+      build_stubbed(:order, shipping_address: address) do |o|
+        allow(o).to receive(:shipping_info_for_order).and_return({shipping_method_name: nil,
+                                                                  delivery_time: nil})
+      end
+    end
+  end
 end

--- a/spec/models/shipping_method_spec.rb
+++ b/spec/models/shipping_method_spec.rb
@@ -29,4 +29,48 @@ RSpec.describe ShippingMethod, type: :model do
     create(:shipping_method, country: :IN)
     expect(build_stubbed(:shipping_method, country: :IN)).to_not be_valid
   end
+
+  describe "#add" do
+    it "creates shipping method with valid attributes" do
+      expect do
+        ShippingMethod.add(shipping_method_valid_attributes)
+      end.to change { ShippingMethod.count }.by(1)
+    end
+  end
+
+  describe "#add_for_countries" do
+    it "creates shipping method with valid attributes" do
+      expect do
+        ShippingMethod.add_for_countries("fedex", countries_to_delivery_time_map)
+      end.to change { ShippingMethod.count }.by(3)
+      # Check data
+      expect(ShippingMethod.where(country: countries_to_delivery_time_map.keys)
+                           .pluck(:name, :country, :delivery_time_in_days))
+        .to match_array(expected_response_add_for_countries)
+    end
+  end
+
+  describe "#delete_for_country" do
+    it "deletes shipping method for a country" do
+      record = create(:shipping_method, country: "IN")
+      expect do
+        ShippingMethod.delete_for_country("IN")
+      end.to change { ShippingMethod.count }.by(-1)
+      expect { record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  private
+
+  def shipping_method_valid_attributes
+    {name: "fedex", country: "IN", delivery_time_in_days: 10}
+  end
+
+  def countries_to_delivery_time_map
+    {IN: 5, US: 2, IT: 3}
+  end
+
+  def expected_response_add_for_countries
+    [["fedex", "IN", 5], ["fedex", "US", 2], ["fedex", "IT", 3]]
+  end
 end

--- a/spec/models/shipping_method_spec.rb
+++ b/spec/models/shipping_method_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe ShippingMethod, type: :model do
     end
   end
 
+  describe "#delivery_info_for_country" do
+    it "delivery_info_for_country for valid country" do
+      shipping_method = build_stubbed(:shipping_method)
+      allow(ShippingMethod).to receive(:delivery_info_for_country).with(shipping_method.country)
+        .and_return({shipping_method_name: shipping_method&.name,
+                                                delivery_time: shipping_method&.delivery_time_in_days})
+    end
+
+    it "delivery_info_for_country for invalid country" do
+      allow(ShippingMethod).to receive(:delivery_info_for_country).with("RANDOM")
+        .and_return({shipping_method_name: nil,
+                                                delivery_time: nil})
+    end
+  end
+
   private
 
   def shipping_method_valid_attributes

--- a/spec/models/shipping_method_spec.rb
+++ b/spec/models/shipping_method_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ShippingMethod, type: :model do
+  it "has a valid factory" do
+    expect(build_stubbed(:shipping_method)).to be_valid
+  end
+
+  it "validates the presence of name" do
+    expect(build_stubbed(:shipping_method, name: nil)).not_to be_valid
+  end
+
+  it "validates the presence of delivery_time_in_days" do
+    expect(build_stubbed(:shipping_method, delivery_time_in_days: nil)).not_to be_valid
+  end
+
+  it "validates the presence of country" do
+    expect(build_stubbed(:shipping_method, country: nil)).not_to be_valid
+  end
+
+  it "validates that any invalid country isn't saved" do
+    expect(build_stubbed(:shipping_method, country: "RANDOM")).not_to be_valid
+  end
+
+  it "validates the numericality of delivery_time_in_days" do
+    expect(build_stubbed(:shipping_method, delivery_time_in_days: 0)).not_to be_valid
+  end
+
+  it "validates uniqueness of country" do
+    create(:shipping_method, country: :IN)
+    expect(build_stubbed(:shipping_method, country: :IN)).to_not be_valid
+  end
+end

--- a/spec/system/checkout_spec.rb
+++ b/spec/system/checkout_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe "Checkout" do
-  it "can be completed" do
+  it "can be completed for a valid country" do
     create(:product)
     order = attributes_for(:order)
     shipping_address = attributes_for(:address)
     credit_card = attributes_for(:credit_card)
-
+    shipping_method = create(:shipping_method, country: shipping_address[:country])
     visit root_path
     click_button "Add to bag"
     fill_in "Email address", with: order[:email]
@@ -15,6 +15,8 @@ RSpec.describe "Checkout" do
     fill_in "City", with: shipping_address[:city]
     fill_in "State", with: shipping_address[:state]
     select ISO3166::Country.find_country_by_alpha2(shipping_address[:country]).name, from: "Country"
+    # expect delivery info on checkout form page when correct country is selected
+    expect_delivery_info_on_page(shipping_method)
     fill_in "Card number", with: credit_card[:number]
     fill_in "Name on card", with: credit_card[:name]
     fill_in "Expiration month", with: credit_card[:exp_month]
@@ -22,6 +24,53 @@ RSpec.describe "Checkout" do
     fill_in "CVC", with: credit_card[:cvc]
     click_button "Confirm order"
 
+    # expect delivery info on summary page
     expect(page).to have_content("THANK YOU!")
+    expect_delivery_info_on_page(shipping_method)
+  end
+
+  it "shouldn't allow submission for country where delivery isn't supported" do
+    create(:product)
+    visit root_path
+    click_button "Add to bag"
+    ShippingMethod.where(country: "IN").delete_all
+    select ISO3166::Country.find_country_by_alpha2("IN").name, from: "Country"
+    # expect delivery info on checkout form page when invalid country is selected
+    ensure_delivery_not_possible
+  end
+
+  it "ensure the working of selected country dropdown" do
+    create(:product)
+    shipping_method = create(:shipping_method, country: "IT")
+    shipping_method2 = create(:shipping_method, country: "DE")
+    visit root_path
+    click_button "Add to bag"
+
+    # Select a valid country
+    select ISO3166::Country.find_country_by_alpha2(shipping_method.country).name, from: "Country"
+    expect_delivery_info_on_page(shipping_method)
+
+    # Select an invalid country
+    ShippingMethod.where(country: "US").delete_all
+    select ISO3166::Country.find_country_by_alpha2("US").name, from: "Country"
+    ensure_delivery_not_possible
+
+    # Select another valid country
+    select ISO3166::Country.find_country_by_alpha2(shipping_method2.country).name, from: "Country"
+    expect_delivery_info_on_page(shipping_method2)
+  end
+
+  def expect_delivery_info_on_page(shipping_method)
+    # Expect delivery method to be shown
+    expect(page).to have_content(shipping_method.name)
+    # Expect delivery time to be shown
+    expect(page).to have_content("within #{shipping_method.delivery_time_in_days} days")
+  end
+
+  def ensure_delivery_not_possible
+    # Expect the page to show the non-deliverable message
+    expect(page).to have_content("we don't deliver in your country yet")
+    # Expect the page to not show Confirm order button
+    expect(page).to have_no_content("Confirm order")
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,16 +30,16 @@
 
 "@hotwired/stimulus@^3.0.1":
   version "3.0.1"
-  resolved "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
   integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
 
-"@hotwired/turbo-rails@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/@hotwired/turbo-rails/-/turbo-rails-7.1.0.tgz"
-  integrity sha512-eB/PTZQYl7dPm51AfBwm0sBpohJ7eir/JmuOfwJG297lEEA8sFcvpxVON/87Ne97OyAOcORZtLpX0KB+t9afyw==
+"@hotwired/turbo-rails@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.1.1.tgz#35c03b92b5c86f0137ed08bef843d955ec9bbe83"
+  integrity sha512-ZXpxUjCfkdbuXfoGrsFK80qsVzACs8xCfie9rt2jMTSN6o1olXVA0Nrk8u02yNEwSiVJm/4QSOa8cUcMj6VQjg==
   dependencies:
     "@hotwired/turbo" "^7.1.0"
-    "@rails/actioncable" "^6.0.0"
+    "@rails/actioncable" "^7.0"
 
 "@hotwired/turbo@^7.1.0":
   version "7.1.0"
@@ -67,10 +67,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rails/actioncable@^6.0.0":
-  version "6.1.4"
-  resolved "https://registry.npmjs.org/@rails/actioncable/-/actioncable-6.1.4.tgz"
-  integrity sha512-0LmSKJTuo2dL6BQ+9xxLnS9lbkyfz2mBGeBnQ2J7o9Bn0l0q+ZC6VuoZMZZXPvABI4QT7Nfknv5WhfKYL+boew==
+"@rails/actioncable@^7.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2.tgz#69a6d999f4087e0537dd38fe0963db1f4305d650"
+  integrity sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA==
+
+"@rails/request.js@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.6.tgz#5f0347a9f363e50ec45118c7134080490cda81d8"
+  integrity sha512-dfFWaQXitYJ4kxrgGJNhDNXX54/v10YgoJqBMVe6lhqs6a4N9WD7goZJEvwin82TtK8MqUNhwfyisgKwM6dMdg==
 
 "@tailwindcss/aspect-ratio@^0.4.0":
   version "0.4.0"


### PR DESCRIPTION
**Related Asignment:** [1](https://github.com/abhishekgupta5/ecommerce-rails-app-test#assignment-1-delivery-estimates)
**Brief:**
* Setup Turbo, Stimulus and @rails/requestjs to allow HTML over the wire. (9172a7b)
* Added the Ajax request that will be fired on clicking submit button. The relevant tag ids are passed along to the rails server as request params. (470663f)
* Added `orders/delivery_info` route in app to respond to this ajax request via turbo_stream response.(a34c95f)
* Added turbostream logic to remove and show Submit button and show delivery information (624782b)
This^ completes the Assignment 1B
* Added shipping info on the summary page (7c8db72) - Assignment 1C
* Minor refactoring in orders controllers (1079f6b)
* Added and updated specs for Assignment 1B and 1C (5c578d8)

**Why is this PR atomic:** There are individual commits that lead to the development of the whole feature. However, this is one Checkout flow from a release point of view. The customer shall see this as a whole. That's why it makes sense to put both Assignment 1B and 1C in this PR

**Note:** https://github.com/nebulab/abhishek-gupta-techincal-test/pull/8 is also related to this change and can go along with this

**Note:** This PR is rebased on the Migration [PR](https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/3) and depends on it to be merged first.
Also in order for this to work, do create a few `shipping_methods` for a few countries (check https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/4 for doing so via rails console).

--------
Rationale behind some decisions -
1. Submit button was to be removed and re-rendered on selecting countries. Hence abstracted it out as a partial in a separate file and wrapped the button inside `turbo_frame_tag`.
2. I think there'd be a better way to get `id of tags in JS controller(`app/javascript/controllers/country_controller.js`) to send in the ajax request.
3. Can possibly use some caching and precompute results to avoid DB call each time`delivery_info_for_country` is called in the ajax request. This will only change in case of CRUD operation in the `shipping_method` table.
4. I am mostly Backend focused and the Hotwire way is fairly new in Rails(from version 7) as well. Hence, this part of the assignment took the most time and a LOT of googling. I might have missed a best practice here and there.
5. Updated the system specs and unit tests as required.