### PR TITLE
Added schema and migrations for ERP data

### DIFF
--- a/db/migrate/20220329171107_create_erp_data.rb
+++ b/db/migrate/20220329171107_create_erp_data.rb
@@ -1,0 +1,12 @@
+class CreateErpData < ActiveRecord::Migration[7.0]
+  def change
+    create_table :erp_data do |t|
+      t.string :entity_id, null: false
+      t.belongs_to :order, null: false, index: false
+      t.index [:entity_id], name: :index_erp_data_on_entity_id_uniq, unique: true
+      t.index [:order_id], name: :index_erp_data_on_order_id_uniq, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_115022) do
+ActiveRecord::Schema.define(version: 2022_03_29_171107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,15 @@ ActiveRecord::Schema.define(version: 2022_03_28_115022) do
     t.string "cvc", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "erp_data", force: :cascade do |t|
+    t.string "entity_id", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["entity_id"], name: "index_erp_data_on_entity_id_uniq", unique: true
+    t.index ["order_id"], name: "index_erp_data_on_order_id_uniq", unique: true
   end
 
   create_table "line_items", force: :cascade do |t|


### PR DESCRIPTION
**Related Asignment:** [2](https://github.com/abhishekgupta5/ecommerce-rails-app-test#assignment-2-erp-integration)
**Brief:** Added migrations to create table `erp_data`. This will be used to store information for the ERP<entity_id> and order id in the system

**Why is this PR atomic:** As a general rule, it's always good to separate migrations from the code. At least in this case, where we are creating a new table. They can be independently deployed, nothing will write or read from the table once deployed. We can merge this, go on a vacation and not worry about these changes at all.

**Note:** This PR is rebased on the Assignment 1 [branch](https://github.com/abhishekgupta5/ecommerce-rails-app-test/tree/abhishekgupta5/delivery-estimates-assignment-1BC). Thus it will contain previous changes if compared against main or any other branch.

----
Rationale behind some decisions -
1. I think that needs correction is that - I have **table_name = `erp_data` and model_name = `ErpDatum`**. Rails inflections in play while generating the new model. This might create confusion and should be consistent. 
2. No foreign key with orders - ERP can be an external system and may need to be abstracted out from the database. Foreign keys bind multiple tables together and this seems like a use case where we may have to keep things independent. This is done at the cost of integrity which is fine to loose here. If an order is being deleted, keeping the existing erp record
doesn't harm us.
3. Rationale behind individual `order_id` and `entity_id` indexes - ERP system administrators may query the data with either order or entity. Hence this takes care of the uniqueness and allow fast search based on the search field.