### PR TITLE
Assignment 2: ERP integration functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "image_processing"
 # Schema validation
 gem "json-schema"
 
+# For HTTP requests
+gem "httparty"
+
 group :development, :test do
   # Debugging
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
     ffi (1.15.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     i18n_data (0.16.0)
@@ -124,10 +127,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.4.2)
+    multi_xml (0.6.0)
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
@@ -262,6 +269,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  httparty
   image_processing
   jsbundling-rails
   json-schema

--- a/app/jobs/erp_updater_job.rb
+++ b/app/jobs/erp_updater_job.rb
@@ -1,0 +1,7 @@
+class ErpUpdaterJob < ApplicationJob
+  queue_as :default
+
+  def perform(order)
+    ErpDatum.update_erp_data(order)
+  end
+end

--- a/app/models/erp_datum.rb
+++ b/app/models/erp_datum.rb
@@ -1,0 +1,4 @@
+class ErpDatum < ApplicationRecord
+  # We assume that there is 1-1 relation of an erp_data row and order
+  belongs_to :order
+end

--- a/app/models/erp_datum.rb
+++ b/app/models/erp_datum.rb
@@ -4,4 +4,21 @@ class ErpDatum < ApplicationRecord
 
   validates :entity_id, presence: true
   validates :order_id, presence: true
+
+  class << self
+    def update_erp_data(order)
+      entity_id = fetch(order)
+      save_in_db(entity_id, order)
+    end
+
+    private
+
+    def fetch(order)
+      ErpClient.new(order).post["id"]
+    end
+
+    def save_in_db(entity_id, order)
+      ErpDatum.create!(entity_id: entity_id, order: order)
+    end
+  end
 end

--- a/app/models/erp_datum.rb
+++ b/app/models/erp_datum.rb
@@ -14,7 +14,7 @@ class ErpDatum < ApplicationRecord
     private
 
     def fetch(order)
-      ErpClient.new(order).post["id"]
+      ErpClient.new(order).erp_for_order["id"]
     end
 
     def save_in_db(entity_id, order)

--- a/app/models/erp_datum.rb
+++ b/app/models/erp_datum.rb
@@ -1,4 +1,7 @@
 class ErpDatum < ApplicationRecord
   # We assume that there is 1-1 relation of an erp_data row and order
   belongs_to :order
+
+  validates :entity_id, presence: true
+  validates :order_id, presence: true
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -19,13 +19,15 @@ class Order < ApplicationRecord
     line_items.sum(&:total)
   end
 
-  def associate_erp_and_order
-    ErpUpdaterJob.perform_later(self)
-  end
-
   # @return [Hash] containing shipping_method_name and
   # delivery_time(in days)
   def shipping_info_for_order
     ShippingMethod.delivery_info_for_country(shipping_address.country)
+  end
+
+  private
+
+  def associate_erp_and_order
+    ErpUpdaterJob.perform_later(self)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,6 +15,11 @@ class Order < ApplicationRecord
     line_items.sum(&:total)
   end
 
+  # TODO: Run async in a sidekiq job when order is created
+  def associate_erp_and_order
+    ErpDatum.update_erp_data(self)
+  end
+
   # @return [Hash] containing shipping_method_name and
   # delivery_time(in days)
   def shipping_info_for_order

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,6 +2,8 @@ class Order < ApplicationRecord
   belongs_to :shipping_address, class_name: "Address"
   belongs_to :credit_card
 
+  # We assume that there is 1-1 relation of an erp_data row and order
+  has_one :erp_data_row, class_name: "ErpDatum"
   has_many :line_items, inverse_of: :order
 
   accepts_nested_attributes_for :shipping_address

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,10 @@ module RailsTechnicalTest
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Use rails inbuilt async threadpool as active job backend
+    # In an ideal production system, this would be sidekiq or any other
+    # job processing backend running it's own server
+    config.active_job.queue_adapter = :async
   end
 end

--- a/lib/erp_client.rb
+++ b/lib/erp_client.rb
@@ -1,0 +1,61 @@
+class ErpClient
+  include Errors
+  include HTTParty
+  base_uri "http://localhost:3000"
+  ERP_ENDPOINT = "/erp/orders"
+
+  attr_reader :order
+
+  def initialize(order)
+    @order = order
+    @address = order.shipping_address
+  end
+
+  def post(body: {})
+    handle_errors(body)
+  end
+
+  private
+
+  def handle_errors(body)
+    response = self.class.post(ERP_ENDPOINT, body: body.merge!(order_payload).to_json, headers: auth_headers)
+    case response.code
+    when 201
+      response
+    when (400..499)
+      raise ErpClientError
+    when (500..599)
+      raise ErpServerError
+    end
+  end
+
+  def order_payload
+    # This will generate only 2 DB queries.
+    # 1. To get line_items scoped by orders
+    # 2. To get products scoped by line items
+    line_items_data = LineItem.includes(:product).where(order: order).map do |item|
+      {product_description: item.product.name,
+       quantity: item.quantity,
+       total: item.total.to_f}
+    end
+    {
+      order_id: order.id,
+      shipping_address: {
+        full_name: "#{@address.first_name} #{@address.last_name}",
+        line1: @address.line1,
+        line2: nil, # Not sure why this is expecting null in the JSON schema
+        zip: @address.zip,
+        city: @address.city,
+        state: @address.state,
+        country: @address.country
+      },
+      line_items: line_items_data,
+      total: order.total.to_f
+    }
+  end
+
+  def auth_headers
+    {"Content-Type" => "application/json",
+     "Accept" => "application/json"}
+  end
+end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,0 +1,13 @@
+module Errors
+  class ErpClientError < StandardError
+    def message
+      "Client error. Fix the request and try again"
+    end
+  end
+
+  class ErpServerError < StandardError
+    def message
+      "Something gone bad on our end"
+    end
+  end
+end

--- a/spec/clients/erp_client_spec.rb
+++ b/spec/clients/erp_client_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe ErpClient do
+  describe "#erp_for_order" do
+    let(:order) { build_stubbed(:order) }
+    let(:address) { order.shipping_address }
+    let(:line_item) { build_stubbed(:line_item, order: order) }
+
+    after(:each) do
+      # Expect that the HTTP request was made with correct arguments at all times
+      expect(ErpClient).to have_received(:post).with(ErpClient::ERP_ENDPOINT, body: request_body.to_json, headers: auth_headers)
+    end
+
+    it "success" do
+      # Stub the API response for a successful scenario
+      stub_response = instance_double("HTTParty::Response", code: 201, parsed_response: success_response)
+      allow(ErpClient).to receive(:post) { stub_response }
+
+      response = ErpClient.new(order).erp_for_order
+
+      expect(response).to eq(success_response)
+    end
+
+    it "failure - ClientError" do
+      # Stub the API response for a failure scenario with client error
+      stub_response = instance_double("HTTParty::Response", code: 422)
+      allow(ErpClient).to receive(:post) { stub_response }
+
+      expect { ErpClient.new(order).erp_for_order }.to raise_error(Errors::ErpClientError)
+    end
+
+    it "failure - ServerError" do
+      # Stub the API response for a failure scenario with server error
+      stub_response = instance_double("HTTParty::Response", code: 500)
+      allow(ErpClient).to receive(:post) { stub_response }
+
+      expect { ErpClient.new(order).erp_for_order }.to raise_error(Errors::ErpServerError)
+    end
+
+    ####### Helper methods
+    def success_response
+      {"id" => "stubbed_response"}
+    end
+
+    def request_body
+      line_items_data = LineItem.includes(:product).where(order: order).map do |item|
+        {product_description: item.product.name,
+         quantity: item.quantity,
+         total: item.total.to_f}
+      end
+      {
+        order_id: order.id,
+        shipping_address: {
+          full_name: "#{address.first_name} #{address.last_name}",
+          line1: address.line1,
+          line2: nil,
+          zip: address.zip,
+          city: address.city,
+          state: address.state,
+          country: address.country
+        },
+        line_items: line_items_data,
+        total: order.total.to_f
+      }
+    end
+
+    def auth_headers
+      {"Content-Type" => "application/json",
+       "Accept" => "application/json"}
+    end
+  end
+end

--- a/spec/factories/erp_data.rb
+++ b/spec/factories/erp_data.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :erp_datum do
+    order
+    entity_id { "or_#{SecureRandom.hex(8)}" }
+  end
+end

--- a/spec/jobs/erp_updater_job_spec.rb
+++ b/spec/jobs/erp_updater_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe ErpUpdaterJob, type: :job do
+  describe "#perform_later" do
+    let(:order) { create(:order) }
+    before(:each) do
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    it "updates ERP data" do
+      expect {
+        ErpUpdaterJob.perform_later(order)
+      }.to have_enqueued_job.with(order)
+    end
+
+    it "job scheduled with no wait time on default queue" do
+      expect {
+        ErpUpdaterJob.perform_later(order)
+      }.to have_enqueued_job.with(order).on_queue(:default).at(:no_wait).exactly(:once)
+    end
+  end
+end

--- a/spec/models/erp_datum_spec.rb
+++ b/spec/models/erp_datum_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe ErpDatum, type: :model do
+  it "validates the presence of entity_id" do
+    expect(build_stubbed(:erp_datum, entity_id: nil)).not_to be_valid
+  end
+
+  it "validates the presence of order_id" do
+    expect(build_stubbed(:erp_datum, order_id: nil)).not_to be_valid
+  end
+end

--- a/spec/models/erp_datum_spec.rb
+++ b/spec/models/erp_datum_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ErpDatum, type: :model do
     def stub_erp_client_response(order)
       client = double("ErpClient")
       allow(ErpClient).to receive(:new).with(order) { client }
-      allow(client).to receive(:post) { client_response }
+      allow(client).to receive(:erp_for_order) { client_response }
     end
   end
 end

--- a/spec/models/erp_datum_spec.rb
+++ b/spec/models/erp_datum_spec.rb
@@ -8,4 +8,33 @@ RSpec.describe ErpDatum, type: :model do
   it "validates the presence of order_id" do
     expect(build_stubbed(:erp_datum, order_id: nil)).not_to be_valid
   end
+
+  describe "#update_erp_data" do
+    it "save erp data on success" do
+      order = build_stubbed(:order)
+
+      # Stub client response. We want this spec to be independent of what
+      # client does. With this, any changes in client won't need this spec to
+      # change. Only client_response method can change if the response changes.
+      stub_erp_client_response(order)
+
+      # Ensure that the erp row is not already present
+      expect(ErpDatum.where(order: order)).not_to exist
+      # No need to test the private methods fetch and save_in_db individually.
+      # Testing update_erp_data is necessary and sufficient.
+      expect { ErpDatum.update_erp_data(order) }.to change { ErpDatum.count }.by(1)
+      # The ERP row should be saved with proper order_id and entity_id
+      expect(ErpDatum.where(order: order, entity_id: client_response["id"])).to exist
+    end
+
+    def client_response
+      {"id" => "or_aeda3f023dcdce28"}
+    end
+
+    def stub_erp_client_response(order)
+      client = double("ErpClient")
+      allow(ErpClient).to receive(:new).with(order) { client }
+      allow(client).to receive(:post) { client_response }
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -43,4 +43,16 @@ RSpec.describe Order do
       end
     end
   end
+
+  describe "#callbacks" do
+    it "associate_erp_and_order" do
+      ActiveJob::Base.queue_adapter = :test
+      # The important thing to test here is not what happens in the ErpUpdaterJob
+      # job or even the name of the callback.
+      # But instead whether the job is being triggered in an async manner
+      # once an order is being created
+      expect(ErpUpdaterJob).to receive(:perform_later).exactly(:once)
+      create(:order)
+    end
+  end
 end

--- a/spec/requests/erp/orders_spec.rb
+++ b/spec/requests/erp/orders_spec.rb
@@ -3,10 +3,7 @@ RSpec.describe "/erp/orders" do
     it "responds with 201 Created" do
       payload = build_payload
 
-      post erp_orders_path, params: payload.to_json, headers: {
-        "Content-Type" => "application/json",
-        "Accept" => "application/json"
-      }
+      post erp_orders_path, params: payload.to_json, headers: json_headers
 
       expect(response.status).to eq(201)
     end
@@ -14,10 +11,7 @@ RSpec.describe "/erp/orders" do
     it "responds with the entity ID" do
       payload = build_payload
 
-      post erp_orders_path, params: payload.to_json, headers: {
-        "Content-Type" => "application/json",
-        "Accept" => "application/json"
-      }
+      post erp_orders_path, params: payload.to_json, headers: json_headers
 
       expect(JSON.parse(response.body)).to match("id" => an_instance_of(String))
     end
@@ -25,10 +19,7 @@ RSpec.describe "/erp/orders" do
     it "validates the request payload" do
       payload = {invalid: "data"}
 
-      post erp_orders_path, params: payload.to_json, headers: {
-        "Content-Type" => "application/json",
-        "Accept" => "application/json"
-      }
+      post erp_orders_path, params: payload.to_json, headers: json_headers
 
       expect(response.status).to eq(422)
     end
@@ -55,5 +46,10 @@ RSpec.describe "/erp/orders" do
       }],
       total: 30.0
     }
+  end
+
+  def json_headers
+    {"Content-Type" => "application/json",
+     "Accept" => "application/json"}
   end
 end

--- a/spec/system/checkout_spec.rb
+++ b/spec/system/checkout_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Checkout" do
-  it "can be completed for a valid country" do
+  it "can be completed for a valid country and ERP data updated" do
+    ActiveJob::Base.queue_adapter = :test
     create(:product)
     order = attributes_for(:order)
     shipping_address = attributes_for(:address)
@@ -27,6 +28,11 @@ RSpec.describe "Checkout" do
     # expect delivery info on summary page
     expect(page).to have_content("THANK YOU!")
     expect_delivery_info_on_page(shipping_method)
+
+    # Note: Whether the job got Enqueued is enough to check here. We don't need to
+    # check the exact data when the job finishes. That will be covered in other specs
+    # related to the work being done in the job
+    expect(ErpUpdaterJob).to have_been_enqueued
   end
 
   it "shouldn't allow submission for country where delivery isn't supported" do


### PR DESCRIPTION
**Related Asignment:** [2](https://github.com/abhishekgupta5/ecommerce-rails-app-test#assignment-2-erp-integration)
**Brief:**
* Added associations between ErpData and Order (488052a)
* Added Added ERP model validations, factory and specs  (5a9f364)
* Added HTTParty gem to do POST request on the ERP API (f18f643)
* Added ErpClient to do the post request and basic error handling (5091dca)
* Refactored the ErpClient and added client specs (1abf916)
* Added glue code to fetch and update ERP data (1714218)
* Made the ERP functionality async of order creation (6ac1116)
* Added specs related to ERP system (3f4aa7d)
* Minor refactoring (3e479f2 and 1f4a1b2)

**Update:** I have abstracted out the ErpClient code and specs in a separate [PR](https://github.com/nebulab/abhishek-gupta-techincal-test/pull/9) which I'd recommend to review and merge first. It's independently of this PR. The client is written in such a way that it can be abstracted out as a separate gem in future if needed. If [that](https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/9) PR is merged in the base [branch](https://github.com/abhishekgupta5/ecommerce-rails-app-test/tree/abhishekgupta5/erp-integration-migrations) first, the client changes will not be shown in this PR which would make this easier to review.

**Why is this PR atomic:** There are individual commits that lead to the development of the whole feature. However, this is one ERP flow from a release point of view. The customer shall see this as a whole. That's why it makes sense to put both Assignment 1B and 1C in this PR

**Note:** This PR is rebased on the Migration [PR](https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/6) and depends on it to be merged first.
In order to get this to work, create an order (via rails console or checkout form) and check the `ErpData` row in the database for that order.

--------
Rationale behind some decisions -
1. On each order creation, an async job is triggered which does the work specified in commit(6ac1116). For simplicity and avoiding to run another server, I have used the default rails async queuing implementation that'll run the job in an in-process threadpool. Ideally, the async backend will be sidekiq or related job schedulers with explicit server process.
2. **TODO[abhishek]:**  Add retry mechanism for retryable errors while interacting with ERP client. In essence to save time, I have ignored this at the moment. Let me know if we need this right now.