### PR TITLE
Assignment 1B and 1C- Don't allow order creation for non-deliverable addresses from server side

### DIFF
--- a/app/models/shipping_method.rb
+++ b/app/models/shipping_method.rb
@@ -48,5 +48,13 @@ class ShippingMethod < ApplicationRecord
       {shipping_method_name: shipping_method&.name,
        delivery_time: shipping_method&.delivery_time_in_days}
     end
+
+    # This method can be cached for avoiding DB calls.
+    # Cache can be invalidated when a new shipping method
+    # is added or when country changes for an existing
+    # shipping method
+    def allowed_countries_for_shipping
+      ShippingMethod.pluck(:country)
+    end
   end
 end

--- a/spec/jobs/erp_updater_job_spec.rb
+++ b/spec/jobs/erp_updater_job_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe ErpUpdaterJob, type: :job do
   describe "#perform_later" do
-    let(:order) { create(:order) }
+    let(:shipping_method) { create(:shipping_method) }
+    let(:address) { create(:address, country: shipping_method.country) }
+    let(:order) { create(:order, shipping_address: address) }
     before(:each) do
       ActiveJob::Base.queue_adapter = :test
     end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,6 +1,17 @@
 RSpec.describe Order do
+  let(:shipping_method) { create(:shipping_method) }
+  let(:address) { create(:address, country: shipping_method.country) }
+
   it "has a valid factory" do
-    expect(build_stubbed(:order)).to be_valid
+    expect(build_stubbed(:order, shipping_address: address)).to be_valid
+  end
+
+  it "validates allowed_countries_for_shipping" do
+    ShippingMethod.delete_all
+    order = build_stubbed(:order)
+    expect(order).not_to be_valid
+    # Check error message
+    expect(order.errors.full_messages).to include(/We don't deliver to/)
   end
 
   it "validates the presence of email" do
@@ -52,7 +63,7 @@ RSpec.describe Order do
       # But instead whether the job is being triggered in an async manner
       # once an order is being created
       expect(ErpUpdaterJob).to receive(:perform_later).exactly(:once)
-      create(:order)
+      create(:order, shipping_address: address)
     end
   end
 end


### PR DESCRIPTION
**Related assignment -** [1](https://github.com/abhishekgupta5/ecommerce-rails-app-test#assignment-1-delivery-estimates)
This PR is in addtion to https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/5 for Assignment 1B and 1C.
It was done 

**Brief  and Rationale:** We used to not let users click on submit button when they select a non-deliverable country. However this isn't enough. The backend needs to enforce it. [This](fd5a02b866cad60f01fc1ee49be264dacd3a44f6) commit ensures that. Related tests are fixed and new tests added

**Why this PR is atomic:** This PR doesn't break any backwards/forward compatibility and can be merged anytime after https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/5