### PR TITLE
Assignment 2 - HTTParty gem, ERP client and specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "image_processing"
 # Schema validation
 gem "json-schema"
 
+# For HTTP requests
+gem "httparty"
+
 group :development, :test do
   # Debugging
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
     ffi (1.15.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     i18n_data (0.16.0)
@@ -124,10 +127,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.4.2)
+    multi_xml (0.6.0)
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
@@ -262,6 +269,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  httparty
   image_processing
   jsbundling-rails
   json-schema

--- a/app/models/erp_datum.rb
+++ b/app/models/erp_datum.rb
@@ -1,0 +1,24 @@
+class ErpDatum < ApplicationRecord
+  # We assume that there is 1-1 relation of an erp_data row and order
+  belongs_to :order
+
+  validates :entity_id, presence: true
+  validates :order_id, presence: true
+
+  class << self
+    def update_erp_data(order)
+      entity_id = fetch(order)
+      save_in_db(entity_id, order)
+    end
+
+    private
+
+    def fetch(order)
+      ErpClient.new(order).erp_for_order["id"]
+    end
+
+    def save_in_db(entity_id, order)
+      ErpDatum.create!(entity_id: entity_id, order: order)
+    end
+  end
+end

--- a/lib/erp_client.rb
+++ b/lib/erp_client.rb
@@ -1,0 +1,61 @@
+class ErpClient
+  include Errors
+  include HTTParty
+  base_uri "http://localhost:3000"
+  ERP_ENDPOINT = "/erp/orders"
+
+  attr_reader :order
+
+  def initialize(order)
+    @order = order
+    @address = order.shipping_address
+  end
+
+  def post(body: {})
+    handle_errors(body)
+  end
+
+  private
+
+  def handle_errors(body)
+    response = self.class.post(ERP_ENDPOINT, body: body.merge!(order_payload).to_json, headers: auth_headers)
+    case response.code
+    when 201
+      response
+    when (400..499)
+      raise ErpClientError
+    when (500..599)
+      raise ErpServerError
+    end
+  end
+
+  def order_payload
+    # This will generate only 2 DB queries.
+    # 1. To get line_items scoped by orders
+    # 2. To get products scoped by line items
+    line_items_data = LineItem.includes(:product).where(order: order).map do |item|
+      {product_description: item.product.name,
+       quantity: item.quantity,
+       total: item.total.to_f}
+    end
+    {
+      order_id: order.id,
+      shipping_address: {
+        full_name: "#{@address.first_name} #{@address.last_name}",
+        line1: @address.line1,
+        line2: nil, # Not sure why this is expecting null in the JSON schema
+        zip: @address.zip,
+        city: @address.city,
+        state: @address.state,
+        country: @address.country
+      },
+      line_items: line_items_data,
+      total: order.total.to_f
+    }
+  end
+
+  def auth_headers
+    {"Content-Type" => "application/json",
+     "Accept" => "application/json"}
+  end
+end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,0 +1,13 @@
+module Errors
+  class ErpClientError < StandardError
+    def message
+      "Client error. Fix the request and try again"
+    end
+  end
+
+  class ErpServerError < StandardError
+    def message
+      "Something gone bad on our end"
+    end
+  end
+end

--- a/spec/clients/erp_client_spec.rb
+++ b/spec/clients/erp_client_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe ErpClient do
+  describe "#erp_for_order" do
+    let(:order) { build_stubbed(:order) }
+    let(:address) { order.shipping_address }
+    let(:line_item) { build_stubbed(:line_item, order: order) }
+
+    after(:each) do
+      # Expect that the HTTP request was made with correct arguments at all times
+      expect(ErpClient).to have_received(:post).with(ErpClient::ERP_ENDPOINT, body: request_body.to_json, headers: auth_headers)
+    end
+
+    it "success" do
+      # Stub the API response for a successful scenario
+      stub_response = instance_double("HTTParty::Response", code: 201, parsed_response: success_response)
+      allow(ErpClient).to receive(:post) { stub_response }
+
+      response = ErpClient.new(order).erp_for_order
+
+      expect(response).to eq(success_response)
+    end
+
+    it "failure - ClientError" do
+      # Stub the API response for a failure scenario with client error
+      stub_response = instance_double("HTTParty::Response", code: 422)
+      allow(ErpClient).to receive(:post) { stub_response }
+
+      expect { ErpClient.new(order).erp_for_order }.to raise_error(Errors::ErpClientError)
+    end
+
+    it "failure - ServerError" do
+      # Stub the API response for a failure scenario with server error
+      stub_response = instance_double("HTTParty::Response", code: 500)
+      allow(ErpClient).to receive(:post) { stub_response }
+
+      expect { ErpClient.new(order).erp_for_order }.to raise_error(Errors::ErpServerError)
+    end
+
+    ####### Helper methods
+    def success_response
+      {"id" => "stubbed_response"}
+    end
+
+    def request_body
+      line_items_data = LineItem.includes(:product).where(order: order).map do |item|
+        {product_description: item.product.name,
+         quantity: item.quantity,
+         total: item.total.to_f}
+      end
+      {
+        order_id: order.id,
+        shipping_address: {
+          full_name: "#{address.first_name} #{address.last_name}",
+          line1: address.line1,
+          line2: nil,
+          zip: address.zip,
+          city: address.city,
+          state: address.state,
+          country: address.country
+        },
+        line_items: line_items_data,
+        total: order.total.to_f
+      }
+    end
+
+    def auth_headers
+      {"Content-Type" => "application/json",
+       "Accept" => "application/json"}
+    end
+  end
+end

--- a/spec/models/erp_datum_spec.rb
+++ b/spec/models/erp_datum_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe ErpDatum, type: :model do
+  it "validates the presence of entity_id" do
+    expect(build_stubbed(:erp_datum, entity_id: nil)).not_to be_valid
+  end
+
+  it "validates the presence of order_id" do
+    expect(build_stubbed(:erp_datum, order_id: nil)).not_to be_valid
+  end
+
+  describe "#update_erp_data" do
+    it "save erp data on success" do
+      order = build_stubbed(:order)
+
+      # Stub client response. We want this spec to be independent of what
+      # client does. With this, any changes in client won't need this spec to
+      # change. Only client_response method can change if the response changes.
+      stub_erp_client_response(order)
+
+      # Ensure that the erp row is not already present
+      expect(ErpDatum.where(order: order)).not_to exist
+      # No need to test the private methods fetch and save_in_db individually.
+      # Testing update_erp_data is necessary and sufficient.
+      expect { ErpDatum.update_erp_data(order) }.to change { ErpDatum.count }.by(1)
+      # The ERP row should be saved with proper order_id and entity_id
+      expect(ErpDatum.where(order: order, entity_id: client_response["id"])).to exist
+    end
+
+    def client_response
+      {"id" => "or_aeda3f023dcdce28"}
+    end
+
+    def stub_erp_client_response(order)
+      client = double("ErpClient")
+      allow(ErpClient).to receive(:new).with(order) { client }
+      allow(client).to receive(:erp_for_order) { client_response }
+    end
+  end
+end


### PR DESCRIPTION
**Related Asignment:** [2](https://github.com/abhishekgupta5/ecommerce-rails-app-test#assignment-2-erp-integration)

**Brief:**
1. Added HTTParty gem (d9ec7214c2cffe1d6ce6d514c5026263cb0cfe93)
2. Added ERP client and basic error handling (cd5d88459c04cdf7d8104a7eb23bf0ad93830ffa)
3. Refactored ErpCLient and added client specs (cd5d88459c04cdf7d8104a7eb23bf0ad93830ffa)

The client is written in such a way that it can be abstracted out as a separate gem in future if needed.

**Why this PR is atomic:** This PR can independently go in as this is only an ERP client. It's not being used anywhere hence the same logic applies like migrations for new tables. No existing code is consuming from this.

Also merging this first will make the functionality [PR](https://github.com/abhishekgupta5/ecommerce-rails-app-test/pull/7) easy to review.

----
**TODO[abhishek]:**  Add retry mechanism for retryable errors while interacting with ERP client